### PR TITLE
feat: extend particle trails and expose substeps control

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,13 @@ Customizable with:
 - `sample-opacity`
 
 ### Particles
-Animated particles advected by the wind field.  
+Animated particles advected by the wind field.
 Customizable with:
 - `particle-color`
 - `particle-speed`
+- `particle-size`
+- `particle-trail`
+- `trail-substeps`
 
 ### Arrows
 Vector field arrows at grid points.  

--- a/demo.js
+++ b/demo.js
@@ -70,7 +70,8 @@ var configs = [
             60,  "#f46d43",
             100, "#d53e4f"
           ],
-          "particle-trail": 1.0
+          "particle-trail": 1.0,
+          "trail-substeps": 8
         }
       }
     ],

--- a/dist/windgl.cjs.js
+++ b/dist/windgl.cjs.js
@@ -583,6 +583,14 @@ var Particles = /*@__PURE__*/(function (Layer) {
           transition: true,
           expression: { interpolated: true, parameters: ["zoom"] },
           "property-type": "data-constant"
+        },
+        "trail-substeps": {
+          type: "number",
+          minimum: 1,
+          maximum: 20,
+          default: 8,
+          expression: { interpolated: true, parameters: ["zoom"] },
+          "property-type": "data-constant"
         }
       },
       options
@@ -598,7 +606,7 @@ var Particles = /*@__PURE__*/(function (Layer) {
 
     // Trail effect
     this.trailEnabled = false;
-    this.trailFadeRate = 0.98;
+    this.trailFadeRate = 0.995;
   }
 
   if ( Layer ) Particles.__proto__ = Layer;
@@ -969,8 +977,11 @@ var Particles = /*@__PURE__*/(function (Layer) {
     bindTexture(gl, this.trailTexture, 0);
     bindAttribute(gl, this.fadeQuadBuffer, this.fadeProgram.a_position, 2);
 
-    // Shorter trails as requested
-    var fadeRate = Math.min(0.98, 0.9 + (this.particleTrail || 0.05) * 0.06);
+    // Allow very long trails by fading more slowly
+    var fadeRate = Math.min(
+      0.995,
+      0.9 + (this.particleTrail || 0.05) * 0.095
+    );
     gl.uniform1f(this.fadeProgram.u_fade, fadeRate);
     gl.uniform1i(this.fadeProgram.u_texture, 0);
 
@@ -982,7 +993,7 @@ var Particles = /*@__PURE__*/(function (Layer) {
     gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
 
     var tiles = this.visibleParticleTiles();
-    var SUBSTEPS = 3;
+    var SUBSTEPS = Math.max(1, Math.floor(this.trailSubsteps || 8));
     var baseAlpha = 1.0 / SUBSTEPS;
 
     var loop = function ( s ) {

--- a/dist/windgl.esm.js
+++ b/dist/windgl.esm.js
@@ -579,6 +579,14 @@ var Particles = /*@__PURE__*/(function (Layer) {
           transition: true,
           expression: { interpolated: true, parameters: ["zoom"] },
           "property-type": "data-constant"
+        },
+        "trail-substeps": {
+          type: "number",
+          minimum: 1,
+          maximum: 20,
+          default: 8,
+          expression: { interpolated: true, parameters: ["zoom"] },
+          "property-type": "data-constant"
         }
       },
       options
@@ -594,7 +602,7 @@ var Particles = /*@__PURE__*/(function (Layer) {
 
     // Trail effect
     this.trailEnabled = false;
-    this.trailFadeRate = 0.98;
+    this.trailFadeRate = 0.995;
   }
 
   if ( Layer ) Particles.__proto__ = Layer;
@@ -965,8 +973,11 @@ var Particles = /*@__PURE__*/(function (Layer) {
     bindTexture(gl, this.trailTexture, 0);
     bindAttribute(gl, this.fadeQuadBuffer, this.fadeProgram.a_position, 2);
 
-    // Shorter trails as requested
-    var fadeRate = Math.min(0.98, 0.9 + (this.particleTrail || 0.05) * 0.06);
+    // Allow very long trails by fading more slowly
+    var fadeRate = Math.min(
+      0.995,
+      0.9 + (this.particleTrail || 0.05) * 0.095
+    );
     gl.uniform1f(this.fadeProgram.u_fade, fadeRate);
     gl.uniform1i(this.fadeProgram.u_texture, 0);
 
@@ -978,7 +989,7 @@ var Particles = /*@__PURE__*/(function (Layer) {
     gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
 
     var tiles = this.visibleParticleTiles();
-    var SUBSTEPS = 3;
+    var SUBSTEPS = Math.max(1, Math.floor(this.trailSubsteps || 8));
     var baseAlpha = 1.0 / SUBSTEPS;
 
     var loop = function ( s ) {

--- a/dist/windgl.umd.js
+++ b/dist/windgl.umd.js
@@ -6256,6 +6256,14 @@
             transition: true,
             expression: { interpolated: true, parameters: ["zoom"] },
             "property-type": "data-constant"
+          },
+          "trail-substeps": {
+            type: "number",
+            minimum: 1,
+            maximum: 20,
+            default: 8,
+            expression: { interpolated: true, parameters: ["zoom"] },
+            "property-type": "data-constant"
           }
         },
         options
@@ -6271,7 +6279,7 @@
 
       // Trail effect
       this.trailEnabled = false;
-      this.trailFadeRate = 0.98;
+      this.trailFadeRate = 0.995;
     }
 
     if ( Layer ) Particles.__proto__ = Layer;
@@ -6642,8 +6650,11 @@
       bindTexture(gl, this.trailTexture, 0);
       bindAttribute(gl, this.fadeQuadBuffer, this.fadeProgram.a_position, 2);
 
-      // Shorter trails as requested
-      var fadeRate = Math.min(0.98, 0.9 + (this.particleTrail || 0.05) * 0.06);
+      // Allow very long trails by fading more slowly
+      var fadeRate = Math.min(
+        0.995,
+        0.9 + (this.particleTrail || 0.05) * 0.095
+      );
       gl.uniform1f(this.fadeProgram.u_fade, fadeRate);
       gl.uniform1i(this.fadeProgram.u_texture, 0);
 
@@ -6655,7 +6666,7 @@
       gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
 
       var tiles = this.visibleParticleTiles();
-      var SUBSTEPS = 3;
+      var SUBSTEPS = Math.max(1, Math.floor(this.trailSubsteps || 8));
       var baseAlpha = 1.0 / SUBSTEPS;
 
       var loop = function ( s ) {

--- a/docs/index.js
+++ b/docs/index.js
@@ -6257,6 +6257,14 @@
             transition: true,
             expression: { interpolated: true, parameters: ["zoom"] },
             "property-type": "data-constant"
+          },
+          "trail-substeps": {
+            type: "number",
+            minimum: 1,
+            maximum: 20,
+            default: 8,
+            expression: { interpolated: true, parameters: ["zoom"] },
+            "property-type": "data-constant"
           }
         },
         options
@@ -6272,7 +6280,7 @@
 
       // Trail effect
       this.trailEnabled = false;
-      this.trailFadeRate = 0.98;
+      this.trailFadeRate = 0.995;
     }
 
     if ( Layer ) Particles.__proto__ = Layer;
@@ -6643,8 +6651,11 @@
       bindTexture(gl, this.trailTexture, 0);
       bindAttribute(gl, this.fadeQuadBuffer, this.fadeProgram.a_position, 2);
 
-      // Shorter trails as requested
-      var fadeRate = Math.min(0.98, 0.9 + (this.particleTrail || 0.05) * 0.06);
+      // Allow very long trails by fading more slowly
+      var fadeRate = Math.min(
+        0.995,
+        0.9 + (this.particleTrail || 0.05) * 0.095
+      );
       gl.uniform1f(this.fadeProgram.u_fade, fadeRate);
       gl.uniform1i(this.fadeProgram.u_texture, 0);
 
@@ -6656,7 +6667,7 @@
       gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
 
       var tiles = this.visibleParticleTiles();
-      var SUBSTEPS = 3;
+      var SUBSTEPS = Math.max(1, Math.floor(this.trailSubsteps || 8));
       var baseAlpha = 1.0 / SUBSTEPS;
 
       var loop = function ( s ) {
@@ -7079,7 +7090,8 @@
               60,  "#f46d43",
               100, "#d53e4f"
             ],
-            "particle-trail": 1.0
+            "particle-trail": 1.0,
+            "trail-substeps": 8
           }
         }
       ],

--- a/src/particles.js
+++ b/src/particles.js
@@ -37,6 +37,14 @@ class Particles extends Layer {
           transition: true,
           expression: { interpolated: true, parameters: ["zoom"] },
           "property-type": "data-constant"
+        },
+        "trail-substeps": {
+          type: "number",
+          minimum: 1,
+          maximum: 20,
+          default: 8,
+          expression: { interpolated: true, parameters: ["zoom"] },
+          "property-type": "data-constant"
         }
       },
       options
@@ -52,7 +60,7 @@ class Particles extends Layer {
 
     // Trail effect
     this.trailEnabled = false;
-    this.trailFadeRate = 0.98;
+    this.trailFadeRate = 0.995;
   }
 
   visibleParticleTiles() {
@@ -418,8 +426,11 @@ class Particles extends Layer {
     util.bindTexture(gl, this.trailTexture, 0);
     util.bindAttribute(gl, this.fadeQuadBuffer, this.fadeProgram.a_position, 2);
 
-    // Shorter trails as requested
-    const fadeRate = Math.min(0.98, 0.9 + (this.particleTrail || 0.05) * 0.06);
+    // Allow very long trails by fading more slowly
+    const fadeRate = Math.min(
+      0.995,
+      0.9 + (this.particleTrail || 0.05) * 0.095
+    );
     gl.uniform1f(this.fadeProgram.u_fade, fadeRate);
     gl.uniform1i(this.fadeProgram.u_texture, 0);
 
@@ -431,7 +442,7 @@ class Particles extends Layer {
     gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
 
     const tiles = this.visibleParticleTiles();
-    const SUBSTEPS = 3;
+    const SUBSTEPS = Math.max(1, Math.floor(this.trailSubsteps || 8));
     const baseAlpha = 1.0 / SUBSTEPS;
 
     for (let s = 0; s < SUBSTEPS; s++) {


### PR DESCRIPTION
## Summary
- allow very long particle trails via higher fade cap
- add `trail-substeps` property for smoother, configurable trails
- document particle trail options

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b567d18708832a83fb665a698582fe