### PR TITLE
Remove unused trail fade property

### DIFF
--- a/dist/windgl.cjs.js
+++ b/dist/windgl.cjs.js
@@ -606,7 +606,6 @@ var Particles = /*@__PURE__*/(function (Layer) {
 
     // Trail effect
     this.trailEnabled = false;
-    this.trailFadeRate = 0.995;
   }
 
   if ( Layer ) Particles.__proto__ = Layer;
@@ -977,7 +976,7 @@ var Particles = /*@__PURE__*/(function (Layer) {
     bindTexture(gl, this.trailTexture, 0);
     bindAttribute(gl, this.fadeQuadBuffer, this.fadeProgram.a_position, 2);
 
-    // Allow very long trails by fading more slowly
+    // Allow very long trails by fading more slowly based on the particle-trail setting
     var fadeRate = Math.min(
       0.995,
       0.99 + (this.particleTrail || 0.05) * 0.095

--- a/dist/windgl.esm.js
+++ b/dist/windgl.esm.js
@@ -602,7 +602,6 @@ var Particles = /*@__PURE__*/(function (Layer) {
 
     // Trail effect
     this.trailEnabled = false;
-    this.trailFadeRate = 0.995;
   }
 
   if ( Layer ) Particles.__proto__ = Layer;
@@ -973,7 +972,7 @@ var Particles = /*@__PURE__*/(function (Layer) {
     bindTexture(gl, this.trailTexture, 0);
     bindAttribute(gl, this.fadeQuadBuffer, this.fadeProgram.a_position, 2);
 
-    // Allow very long trails by fading more slowly
+    // Allow very long trails by fading more slowly based on the particle-trail setting
     var fadeRate = Math.min(
       0.995,
       0.99 + (this.particleTrail || 0.05) * 0.095

--- a/dist/windgl.umd.js
+++ b/dist/windgl.umd.js
@@ -6279,7 +6279,6 @@
 
       // Trail effect
       this.trailEnabled = false;
-      this.trailFadeRate = 0.995;
     }
 
     if ( Layer ) Particles.__proto__ = Layer;
@@ -6650,7 +6649,7 @@
       bindTexture(gl, this.trailTexture, 0);
       bindAttribute(gl, this.fadeQuadBuffer, this.fadeProgram.a_position, 2);
 
-      // Allow very long trails by fading more slowly
+      // Allow very long trails by fading more slowly based on the particle-trail setting
       var fadeRate = Math.min(
         0.995,
         0.99 + (this.particleTrail || 0.05) * 0.095

--- a/docs/index.js
+++ b/docs/index.js
@@ -6280,7 +6280,6 @@
 
       // Trail effect
       this.trailEnabled = false;
-      this.trailFadeRate = 0.995;
     }
 
     if ( Layer ) Particles.__proto__ = Layer;
@@ -6651,7 +6650,7 @@
       bindTexture(gl, this.trailTexture, 0);
       bindAttribute(gl, this.fadeQuadBuffer, this.fadeProgram.a_position, 2);
 
-      // Allow very long trails by fading more slowly
+      // Allow very long trails by fading more slowly based on the particle-trail setting
       var fadeRate = Math.min(
         0.995,
         0.99 + (this.particleTrail || 0.05) * 0.095

--- a/src/particles.js
+++ b/src/particles.js
@@ -60,7 +60,6 @@ class Particles extends Layer {
 
     // Trail effect
     this.trailEnabled = false;
-    this.trailFadeRate = 0.995;
   }
 
   visibleParticleTiles() {
@@ -426,7 +425,7 @@ class Particles extends Layer {
     util.bindTexture(gl, this.trailTexture, 0);
     util.bindAttribute(gl, this.fadeQuadBuffer, this.fadeProgram.a_position, 2);
 
-    // Allow very long trails by fading more slowly
+    // Allow very long trails by fading more slowly based on the particle-trail setting
     const fadeRate = Math.min(
       0.995,
       0.99 + (this.particleTrail || 0.05) * 0.095


### PR DESCRIPTION
## Summary
- drop unused `trailFadeRate` property
- clarify trail fade comment to reference `particle-trail` setting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bae6bfe940832ab8bb73d8357daca9