### PR TITLE
Fix texture cleanup for removed particle tiles

### DIFF
--- a/dist/windgl.cjs.js
+++ b/dist/windgl.cjs.js
@@ -647,12 +647,13 @@ var Particles = /*@__PURE__*/(function (Layer) {
 
     Layer.prototype.move.call(this);
     var tiles = this.visibleParticleTiles();
-    Object.keys(this._particleTiles).forEach(function (tile) {
-      if (tiles.filter(function (t) { return t.toString() == tile; }).length === 0) {
+    Object.keys(this._particleTiles).forEach(function (key) {
+      if (tiles.filter(function (t) { return t.toString() == key; }).length === 0) {
         // cleanup
-        this$1$1.gl.deleteTexture(tile.particleStateTexture0);
-        this$1$1.gl.deleteTexture(tile.particleStateTexture1);
-        delete this$1$1._particleTiles[tile];
+        var p = this$1$1._particleTiles[key];
+        this$1$1.gl.deleteTexture(p.particleStateTexture0);
+        this$1$1.gl.deleteTexture(p.particleStateTexture1);
+        delete this$1$1._particleTiles[key];
       }
     });
     tiles.forEach(function (tile) {

--- a/dist/windgl.esm.js
+++ b/dist/windgl.esm.js
@@ -643,12 +643,13 @@ var Particles = /*@__PURE__*/(function (Layer) {
 
     Layer.prototype.move.call(this);
     var tiles = this.visibleParticleTiles();
-    Object.keys(this._particleTiles).forEach(function (tile) {
-      if (tiles.filter(function (t) { return t.toString() == tile; }).length === 0) {
+    Object.keys(this._particleTiles).forEach(function (key) {
+      if (tiles.filter(function (t) { return t.toString() == key; }).length === 0) {
         // cleanup
-        this$1$1.gl.deleteTexture(tile.particleStateTexture0);
-        this$1$1.gl.deleteTexture(tile.particleStateTexture1);
-        delete this$1$1._particleTiles[tile];
+        var p = this$1$1._particleTiles[key];
+        this$1$1.gl.deleteTexture(p.particleStateTexture0);
+        this$1$1.gl.deleteTexture(p.particleStateTexture1);
+        delete this$1$1._particleTiles[key];
       }
     });
     tiles.forEach(function (tile) {

--- a/dist/windgl.umd.js
+++ b/dist/windgl.umd.js
@@ -6320,12 +6320,13 @@
 
       Layer.prototype.move.call(this);
       var tiles = this.visibleParticleTiles();
-      Object.keys(this._particleTiles).forEach(function (tile) {
-        if (tiles.filter(function (t) { return t.toString() == tile; }).length === 0) {
+      Object.keys(this._particleTiles).forEach(function (key) {
+        if (tiles.filter(function (t) { return t.toString() == key; }).length === 0) {
           // cleanup
-          this$1$1.gl.deleteTexture(tile.particleStateTexture0);
-          this$1$1.gl.deleteTexture(tile.particleStateTexture1);
-          delete this$1$1._particleTiles[tile];
+          var p = this$1$1._particleTiles[key];
+          this$1$1.gl.deleteTexture(p.particleStateTexture0);
+          this$1$1.gl.deleteTexture(p.particleStateTexture1);
+          delete this$1$1._particleTiles[key];
         }
       });
       tiles.forEach(function (tile) {

--- a/docs/index.js
+++ b/docs/index.js
@@ -6321,12 +6321,13 @@
 
       Layer.prototype.move.call(this);
       var tiles = this.visibleParticleTiles();
-      Object.keys(this._particleTiles).forEach(function (tile) {
-        if (tiles.filter(function (t) { return t.toString() == tile; }).length === 0) {
+      Object.keys(this._particleTiles).forEach(function (key) {
+        if (tiles.filter(function (t) { return t.toString() == key; }).length === 0) {
           // cleanup
-          this$1$1.gl.deleteTexture(tile.particleStateTexture0);
-          this$1$1.gl.deleteTexture(tile.particleStateTexture1);
-          delete this$1$1._particleTiles[tile];
+          var p = this$1$1._particleTiles[key];
+          this$1$1.gl.deleteTexture(p.particleStateTexture0);
+          this$1$1.gl.deleteTexture(p.particleStateTexture1);
+          delete this$1$1._particleTiles[key];
         }
       });
       tiles.forEach(function (tile) {

--- a/src/particles.js
+++ b/src/particles.js
@@ -95,12 +95,13 @@ class Particles extends Layer {
   move() {
     super.move();
     const tiles = this.visibleParticleTiles();
-    Object.keys(this._particleTiles).forEach((tile) => {
-      if (tiles.filter((t) => t.toString() == tile).length === 0) {
+    Object.keys(this._particleTiles).forEach((key) => {
+      if (tiles.filter((t) => t.toString() == key).length === 0) {
         // cleanup
-        this.gl.deleteTexture(tile.particleStateTexture0);
-        this.gl.deleteTexture(tile.particleStateTexture1);
-        delete this._particleTiles[tile];
+        const p = this._particleTiles[key];
+        this.gl.deleteTexture(p.particleStateTexture0);
+        this.gl.deleteTexture(p.particleStateTexture1);
+        delete this._particleTiles[key];
       }
     });
     tiles.forEach((tile) => {


### PR DESCRIPTION
## Summary
- ensure `move` retrieves particle tile object by key before deleting textures
- avoid misleading variable names in cleanup loop

## Testing
- `npm run build`
- `node -e "const w=require('./dist/windgl.cjs.js'); const layer=w.particles({id:'p', source:{metadata:()=>{}}}); layer.gl={deleteTexture:(tex)=>console.log('delete',tex)}; layer._particleTiles['1']={particleStateTexture0:'tex0',particleStateTexture1:'tex1'}; layer.visibleParticleTiles=()=>[]; layer.move();"`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bae6c3608c832a86fac5ca88c980b5