### PR TITLE
Document particle trail range in docs and demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Customizable with:
 - `particle-color`
 - `particle-speed`
 - `particle-size`
-- `particle-trail`
+- `particle-trail` (default `0.05`, max `2`)
 - `trail-substeps`
 
 ### Arrows

--- a/demo.js
+++ b/demo.js
@@ -70,7 +70,8 @@ var configs = [
             60,  "#f46d43",
             100, "#d53e4f"
           ],
-          "particle-trail": 1.0,
+          // Values above 1 leave longer, slower-fading trails (max 2)
+          "particle-trail": 1.5,
           "trail-substeps": 8
         }
       }

--- a/docs/index.js
+++ b/docs/index.js
@@ -7091,7 +7091,8 @@
               60,  "#f46d43",
               100, "#d53e4f"
             ],
-            "particle-trail": 1.0,
+            // Values above 1 leave longer, slower-fading trails (max 2)
+            "particle-trail": 1.5,
             "trail-substeps": 8
           }
         }


### PR DESCRIPTION
## Summary
- Note `particle-trail` default and 0–2 range in README
- Demonstrate using a >1 `particle-trail` value in examples and describe the effect

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bae6c54460832abc4eff4bbf992dac